### PR TITLE
Bugfix: Openapi generator fails if child in ListSerializer is a field

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -364,7 +364,7 @@ class AutoSchema(ViewInspector):
         if isinstance(field, serializers.ListSerializer):
             return {
                 'type': 'array',
-                'items': self.map_serializer(field.child)
+                'items': self.map_field(field.child)
             }
         if isinstance(field, serializers.Serializer):
             data = self.map_serializer(field)

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -77,11 +77,11 @@ class TestFieldMapping(TestCase):
             (serializers.ListField(child=serializers.ChoiceField(choices=[
                 (1, 'One'), ('a', 'Choice A'), (1.1, 'First'), (1.1, 'First'), (1, 'One'), ('a', 'Choice A'), (1, 'One')
             ])),
-             {'items': {'enum': [1, 'a', 1.1]}, 'type': 'array'}),
+                {'items': {'enum': [1, 'a', 1.1]}, 'type': 'array'}),
             (serializers.ListField(child=serializers.ChoiceField(choices=[
                 (1, 'One'), (2, 'Two'), (3, 'Three'), (2, 'Two'), (3, 'Three'), (1, 'One'),
             ])),
-             {'items': {'enum': [1, 2, 3], 'type': 'integer'}, 'type': 'array'}),
+                {'items': {'enum': [1, 2, 3], 'type': 'integer'}, 'type': 'array'}),
             (serializers.IntegerField(min_value=2147483648),
              {'type': 'integer', 'minimum': 2147483648, 'format': 'int64'}),
             (NestedSerializer(),
@@ -545,8 +545,8 @@ class TestOperationIntrospection(TestCase):
             'o2': reused_object,
         }
         assert (
-                renderer.render(data) == b'o1:\n  test: test\no2:\n  test: test\n' or
-                renderer.render(data) == b'o2:\n  test: test\no1:\n  test: test\n'  # py <= 3.5
+            renderer.render(data) == b'o1:\n  test: test\no2:\n  test: test\n' or
+            renderer.render(data) == b'o2:\n  test: test\no1:\n  test: test\n'  # py <= 3.5
         )
 
     def test_serializer_filefield(self):


### PR DESCRIPTION
The openapi generator fails for serializers like:

    class FloatListSerializer(ListSerializer):
         child=FloatField()

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
